### PR TITLE
chore(ci): add Ubuntu Resolute Raccoon to container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -23,6 +23,8 @@ jobs:
             codename: jammy
           - os: ubuntu
             codename: focal
+          - os: ubuntu
+            codename: resolute    
           - os: debian
             codename: bullseye
           - os: debian

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -7,8 +7,9 @@
 #    `COPY --from=kaspar030/git-cache:<version>-<codename>` /git-cache /usr/bin
 #
 # `version`: every semver combination should work (0, 0.1, 0.1.17, ...)
-# `codename` is either one of "bullseye", "bookworm" or "trixie", or one of "focal", "jammy", or "noble"
-# or "debian-latest", or "ubuntu-latest".
+# `codename` is either one of "bullseye", "bookworm" or "trixie" for Debian,
+#            or one of "focal", "jammy", "noble" or "resolute" for Ubuntu,
+#            or "debian-latest", or "ubuntu-latest".
 #
 ARG DEBIAN_FROM=ubuntu:latest
 FROM ${DEBIAN_FROM} AS builder


### PR DESCRIPTION
To update the `riotbuild` container to Ubuntu 26.04 LTS Resolute Raccoon, a build for Resolute is required.

This PR is based on #117.